### PR TITLE
Small formatting changes and JS modification

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,16 +11,17 @@
 
   <body>
     As you update the four fields, the numberline updates automatically.
-    <div id=form>
+    <form id="form">
       Minimum hours:
-      <input type=number step=0.25 id=min_hours class=hours_input value=15></input>
+      <input type="number" min="0" step="0.25" id="min_hours" class="hours_input" value="15"></input>
       Desired hours:
-      <input type=number step=0.25 id=desired_hours class=hours_input value=20></input>
+      <input type="number" min="0" step="0.25" id="desired_hours" class="hours_input" value="20"></input>
       Assigned hours:
-      <input type=number step=0.25 id=assigned_hours class=hours_input value=21.75></input>
+      <input type="number" min="0" step="0.25" id="assigned_hours" class="hours_input" value="21.75"></input>
       Maximum hours:
-      <input type=number step=0.25 id=max_hours class=hours_input value=25></input>
-    </div>
+      <input type=number min="0" step="0.25" id="max_hours" class="hours_input" value="25"></input>
+      <button type=submit hidden="true">Submit</button>
+    </form>
     <div id=numberline class=canvas></div>
     (<a href="https://github.com/dfaulken/numberline">source</a>)
   </body>

--- a/index.html
+++ b/index.html
@@ -13,13 +13,13 @@
     As you update the four fields, the numberline updates automatically.
     <div id=form>
       Minimum hours:
-      <input type=number step=0.25 id=min_hours value=15></input>
+      <input type=number step=0.25 id=min_hours class=hours_input value=15></input>
       Desired hours:
-      <input type=number step=0.25 id=desired_hours value=20></input>
+      <input type=number step=0.25 id=desired_hours class=hours_input value=20></input>
       Assigned hours:
-      <input type=number step=0.25 id=assigned_hours value=21.75></input>
+      <input type=number step=0.25 id=assigned_hours class=hours_input value=21.75></input>
       Maximum hours:
-      <input type=number step=0.25 id=max_hours value=25></input>
+      <input type=number step=0.25 id=max_hours class=hours_input value=25></input>
     </div>
     <div id=numberline class=canvas></div>
     (<a href="https://github.com/dfaulken/numberline">source</a>)

--- a/main.css
+++ b/main.css
@@ -6,5 +6,5 @@
   margin: 30px 0;
   background-color: lightgrey;
   width: 900px;
-  height: 150px;
+  height: 200px;
 }

--- a/main.js
+++ b/main.js
@@ -35,8 +35,8 @@ function drawNumberline(){
 
   // draw the minimum hours circle
   var minPixels = placeHours(hours.min, lowest, highest, lineStart.x, lineEnd.x);
-  //var minCircle = paper.circle(minPixels, circleY, circleRadius);
-  var minCircle = paper.rect(minPixels - 37.5, circleY - 50, 75, 100);
+  var minCircle = paper.circle(minPixels, circleY, circleRadius);
+  //var minCircle = paper.rect(minPixels - 37.5, circleY - 50, 75, 100);
   minCircle.attr({ fill: colors.min, 'stroke-width': 2 });
   paper.text(minPixels, textY, hours.min).attr('font-size', hoursFontSize);
   paper.text(minPixels, descY, 'Minimum')
@@ -44,7 +44,7 @@ function drawNumberline(){
 
   // draw the desired hours circle
   var desiredPixels = placeHours(hours.desired, lowest, highest, lineStart.x, lineEnd.x);
-  var desiredCircle = paper.circle(desiredPixels, circleY, circleRadius - 10);
+  var desiredCircle = paper.circle(desiredPixels, circleY, circleRadius);
   desiredCircle.attr({ fill: colors.desired, 'stroke-width': 2 });
   paper.text(desiredPixels, textY, hours.desired).attr('font-size', hoursFontSize);
   paper.text(desiredPixels, descY, 'Desired')
@@ -52,8 +52,8 @@ function drawNumberline(){
 
   // draw the max hours circle
   var maxPixels = placeHours(hours.max, lowest, highest, lineStart.x, lineEnd.x);
-  //var maxCircle = paper.circle(maxPixels, circleY, circleRadius);
-  var maxCircle = paper.rect(maxPixels - 37.5, circleY - 50, 75, 100);
+  var maxCircle = paper.circle(maxPixels, circleY, circleRadius);
+  //var maxCircle = paper.rect(maxPixels - 37.5, circleY - 50, 75, 100);
   maxCircle.attr({ fill: colors.max, 'stroke-width': 2 });
   paper.text(maxPixels, textY, hours.max).attr('font-size', hoursFontSize);
   paper.text(maxPixels, descY, 'Maximum')
@@ -61,13 +61,13 @@ function drawNumberline(){
 
   // draw the assigned hours circle last, since it's the only one that moves
   var assignedPixels = placeHours(hours.assigned, lowest, highest, lineStart.x, lineEnd.x);
-  var assignedCircle = paper.circle(assignedPixels, circleY, circleRadius);
+  var assignedCircle = paper.circle(assignedPixels, circleY, circleRadius - 10);
   assignedCircle.attr({ fill: colors.assigned, 'stroke-width': 2 });
   paper.text(assignedPixels, textY + 2, hours.assigned)
-       .attr('font-size', hoursFontSize + 2);
+       .attr('font-size', hoursFontSize - 2);
        //.attr('font-weight', 'bold');
   paper.text(assignedPixels, descY + 2, 'Assigned')
-       .attr('font-size', descriptionFontSize + 2);
+       .attr('font-size', descriptionFontSize);
        //.attr('font-weight', 'bold');
 }
 

--- a/main.js
+++ b/main.js
@@ -30,40 +30,45 @@ function drawNumberline(){
   line.attr('stroke-width', '3');
 
   var circleY = lineStart.y;
-  var textY = circleY - 8;
-  var descY = textY + hoursFontSize;
+  var textY = circleY - 1.5;
+  var descY = textY - hoursFontSize - 50;
 
   // draw the minimum hours circle
   var minPixels = placeHours(hours.min, lowest, highest, lineStart.x, lineEnd.x);
-  var minCircle = paper.circle(minPixels, circleY, circleRadius);
+  //var minCircle = paper.circle(minPixels, circleY, circleRadius);
+  var minCircle = paper.rect(minPixels - 37.5, circleY - 50, 75, 100);
   minCircle.attr({ fill: colors.min, 'stroke-width': 2 });
   paper.text(minPixels, textY, hours.min).attr('font-size', hoursFontSize);
-  paper.text(minPixels, descY, 'minimum')
+  paper.text(minPixels, descY, 'Minimum')
        .attr('font-size', descriptionFontSize);
 
   // draw the desired hours circle
   var desiredPixels = placeHours(hours.desired, lowest, highest, lineStart.x, lineEnd.x);
-  var desiredCircle = paper.circle(desiredPixels, circleY, circleRadius);
+  var desiredCircle = paper.circle(desiredPixels, circleY, circleRadius - 10);
   desiredCircle.attr({ fill: colors.desired, 'stroke-width': 2 });
   paper.text(desiredPixels, textY, hours.desired).attr('font-size', hoursFontSize);
-  paper.text(desiredPixels, descY, 'desired')
+  paper.text(desiredPixels, descY, 'Desired')
        .attr('font-size', descriptionFontSize);
 
   // draw the max hours circle
   var maxPixels = placeHours(hours.max, lowest, highest, lineStart.x, lineEnd.x);
-  var maxCircle = paper.circle(maxPixels, circleY, circleRadius);
+  //var maxCircle = paper.circle(maxPixels, circleY, circleRadius);
+  var maxCircle = paper.rect(maxPixels - 37.5, circleY - 50, 75, 100);
   maxCircle.attr({ fill: colors.max, 'stroke-width': 2 });
   paper.text(maxPixels, textY, hours.max).attr('font-size', hoursFontSize);
-  paper.text(maxPixels, descY, 'maximum')
+  paper.text(maxPixels, descY, 'Maximum')
        .attr('font-size', descriptionFontSize);
 
   // draw the assigned hours circle last, since it's the only one that moves
   var assignedPixels = placeHours(hours.assigned, lowest, highest, lineStart.x, lineEnd.x);
-  var assignedCircle = paper.circle(assignedPixels, circleY, circleRadius - 10);
+  var assignedCircle = paper.circle(assignedPixels, circleY, circleRadius);
   assignedCircle.attr({ fill: colors.assigned, 'stroke-width': 2 });
-  paper.text(assignedPixels, textY + 2, hours.assigned).attr('font-size', hoursFontSize - 5);
-  paper.text(assignedPixels, descY - 2, 'assigned')
-       .attr('font-size', descriptionFontSize - 3);
+  paper.text(assignedPixels, textY + 2, hours.assigned)
+       .attr('font-size', hoursFontSize + 2);
+       //.attr('font-weight', 'bold');
+  paper.text(assignedPixels, descY + 2, 'Assigned')
+       .attr('font-size', descriptionFontSize + 2);
+       //.attr('font-weight', 'bold');
 }
 
 function placeHours(hours, minHours, maxHours, lineStartX, lineEndX){
@@ -74,5 +79,9 @@ function placeHours(hours, minHours, maxHours, lineStartX, lineEndX){
 $(document).ready(function(){
   drawNumberline();
 
+  $('input.hours_input').on('change', function(){
+    var val = +$(this).val();
+    $(this).val(val.toFixed(2));
+  });
   $('#form').on('change', 'input', drawNumberline);
 })


### PR DESCRIPTION
As mentioned in the original post,
- Changed 'end points' to be rectangles instead of circles. Seems more intuitive for the bounds to be a more "defined" shape rather than a circle.
- The code will auto-format numbers to two decimal places (as to prevent unneededly long numbers)
- Moved the 'labels' for each bit to above it (so the numbers can be centered and become the focus of the shapes
- Swapped the sizes of 'Desired' versus 'Assigned'. I felt like what you **got** is more important than what you **want** in terms of work hours, so I swapped the two.

![image](https://cloud.githubusercontent.com/assets/9220151/12651856/58f39d4e-c5b6-11e5-888f-9ffedfac042c.png)
